### PR TITLE
Sso/bug editable token descriptor

### DIFF
--- a/src/SSOtests/SSOeditableTokenDesc.html
+++ b/src/SSOtests/SSOeditableTokenDesc.html
@@ -1,0 +1,71 @@
+<html>
+    <head>
+        <script src="http://cdn.kendostatic.com/2014.3.1316/js/jquery.min.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.util.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.session.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.auth.js"></script>	
+        
+    </head>
+
+    <body>
+        <br/>
+        <br/>
+        TEST OUTPUT
+        <br/>
+
+        <script type="text/javascript">
+            // These are tests for the story TP 38665 where we're preventing
+            // the editing of the tokenRequest/ResponseDescriptors.
+                        
+            // Original success case
+            try {
+                document.write("<br/><br/>Successful AuthProvider Check: <br/>");
+                var auth = new progress.data.AuthenticationProvider(
+                    //"http://localhost:8810/TS102/static/auth/j_spring_security_check",
+                    "http://nbbedaestrada:8810/TS102/static/auth/j_spring_security_check"
+                );
+                
+                auth.authenticate({ userName: "restuser", password: "password"})
+                    .done(function (ap, result, info) {
+                    console.log("authenticate method succeeded");
+                
+                })
+                .fail(function (ap, result, info) {
+                    console.log("authenticate method failed");
+                });
+                
+            } catch (e) {
+                console.log("Failure: " + e);
+            } finally {
+                // If this succeeds, our provider should be authenticated
+                // Weird thing, it fails the first time? Even though we are
+                // authenticated?
+                if (auth && auth.isAuthenticated()) {
+                    document.write("Success: we're authenticated!");
+                }
+                else  {
+                    document.write("Failure: We didn't authenticate!");
+                }
+            }
+            
+            // There should be no tokenResponseDescriptor!
+            try {
+                document.write("<br/><br/>Editing of TokenResponseDescriptor Check: <br/>")
+                var test = new progress.data.AuthenticationProvider(
+                    "hello yolo"
+                );
+
+                if (typeof test.tokenResponseDescriptor === "undefined") {
+                    document.writeln("Success: There is no tokenResponseDescriptor!");
+                } else {
+                    document.writeln("Failure: There is a tokenResponseDescriptor!");
+                }
+            } catch (e) {
+                document.write("Exception: " + e);
+            }
+            
+            
+        </script> 
+    </body>
+</html>

--- a/src/SSOtests/SSOemptyUriTest.html
+++ b/src/SSOtests/SSOemptyUriTest.html
@@ -1,0 +1,201 @@
+<html>
+    <head>
+        <script src="http://cdn.kendostatic.com/2014.3.1316/js/jquery.min.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.util.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.session.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.auth.js"></script>	
+        
+    </head>
+
+    
+    <body>
+        <br/>
+        <br/>
+        TEST OUTPUT
+        <br/>
+
+        <script type="text/javascript">
+            // These are tests for the story TP 34435 where we're making sure
+            // providing an empty authenticationURI throws an error.
+            // I also changed a bunch of error messages so this tests that too.
+            
+            // THESE TESTS ARE RELATED TO THE BUG
+            
+            document.write("Empty authenticationURI tests: <br/>");
+            
+            // Original success case
+            try {
+                document.write("<br/><br/>Successful AuthProvider Check: <br/>");
+                var auth = new progress.data.AuthenticationProvider(
+                    //"http://localhost:8810/TS102/static/auth/j_spring_security_check",
+                    "http://nbbedaestrada:8810/TS102/static/auth/j_spring_security_check"
+                );
+                
+                auth.authenticate({ userName: "restuser", password: "password"})
+                    .done(function (ap, result, info) {
+                    console.log("authenticate method succeeded");
+                
+                })
+                .fail(function (ap, result, info) {
+                    console.log("authenticate method failed");
+                });
+                
+            } catch (e) {
+                console.log("Failure: " + e);
+            } finally {
+                // If this succeeds, our provider should be authenticated
+                // Weird thing, it fails the first time? Even though we are
+                // authenticated?
+                if (auth && auth.isAuthenticated()) {
+                    document.write("Success: we're authenticated!");
+                }
+                else  {
+                    document.write("Failure: We didn't authenticate!");
+                }
+            }
+            
+            // Failure case where we give an empty authenticationURI
+            try {
+                document.write("<br/><br/>Empty authURI Check: <br/>")
+                var fail = new progress.data.AuthenticationProvider(
+                    ""
+                );
+                
+                // We should not print out anything
+                document.write("Failure: No exception thrown.");
+            } catch (e) {
+                document.write("Sucess: " + e);
+            }
+            
+            // THESE TESTS ARE RELATED TO ERROR MESSAGE CHANGES
+            
+            document.write("AuthenticationProvider tests: <br/>"); 
+            
+            // Failure case where we have a tokenResponseDescriptor with no type
+            try {
+                document.write("<br/><br/>Empty tokenResponseDescriptor: <br/>")
+                var test = new progress.data.AuthenticationProvider(
+                    "fake.fakerson.com",
+                    {
+                        tokenResponseDescriptor: {}
+                    }
+                    
+                );
+                
+                // We should not print out anything
+                document.write("Failure: No exception thrown.");
+            } catch (e) {
+                document.write("Sucess: " + e);
+            }
+            
+            // Failure case where we have a tokenResponseDescriptor with  an invalid type
+            try {
+                document.write("<br/><br/>Bad type for tokenResponseDescriptor: <br/>")
+                var test = new progress.data.AuthenticationProvider(
+                    "fake.fakerson.com",
+                    {
+                        tokenResponseDescriptor: 
+                        {
+                            type: 5    
+                        }
+                    }
+                    
+                );
+                
+                // We should not print out anything
+                document.write("Failure: No exception thrown.");
+            } catch (e) {
+                document.write("Sucess: " + e);
+            }
+            
+            // Failure case where we have a tokenResponseDescriptor with an empty headerName
+            try {
+                document.write("<br/><br/>Empty headerName for tokenResponseDescriptor: <br/>")
+                var test = new progress.data.AuthenticationProvider(
+                    "fake.fakerson.com",
+                    {
+                        tokenResponseDescriptor: 
+                        {
+                            type: "header",
+                            headerName: ""
+                        }
+                    }
+                    
+                );
+                
+                // We should not print out anything
+                document.write("Failure: No exception thrown.");
+            } catch (e) {
+                document.write("Sucess: " + e);
+            }
+            
+            document.write("AuthenticationConsumer tests: <br/>"); 
+            
+            // Failure case where we have a tokenRequestDescriptor with no type
+            try {
+                document.write("<br/><br/>Empty tokenResponseDescriptor: <br/>")
+                var test = new progress.data.AuthenticationConsumer(
+                    {
+                        tokenRequestDescriptor: {}
+                    }
+                );
+                
+                // We should not print out anything
+                document.write("Failure: No exception thrown.");
+            } catch (e) {
+                document.write("Sucess: " + e);
+            }
+            
+            // Failure case where we have a tokenRequestDescriptor with  an invalid type
+            try {
+                document.write("<br/><br/>Bad type for tokenRequestDescriptor: <br/>")
+                var test = new progress.data.AuthenticationConsumer(
+                    {
+                        tokenRequestDescriptor: 
+                        {
+                            type: 5    
+                        }
+                    }
+                );
+                
+                // We should not print out anything
+                document.write("Failure: No exception thrown.");
+            } catch (e) {
+                document.write("Sucess: " + e);
+            }
+            
+            // Failure case where we have a tokenRequestDescriptor with an empty headerName
+            try {
+                document.write("<br/><br/>Empty headerName for tokenRequestDescriptor: <br/>")
+                var test = new progress.data.AuthenticationConsumer(
+                    {
+                        tokenRequestDescriptor: 
+                        {
+                            type: "header",
+                            headerName: ""
+                        }
+                    }
+                );
+                
+                // We should not print out anything
+                document.write("Failure: No exception thrown.");
+            } catch (e) {
+                document.write("Sucess: " + e);
+            }
+            
+                // Failure case where where options is not an object
+            try {
+                document.write("<br/><br/>AuthenticationConsumer options is not an object: <br/>")
+                var test = new progress.data.AuthenticationConsumer("fail!");
+                
+                // We should not print out anything
+                document.write("Failure: No exception thrown.");
+            } catch (e) {
+                document.write("Sucess: " + e);
+            }
+            
+            
+        </script> 
+    </body>
+</html>

--- a/src/progress.auth.js
+++ b/src/progress.auth.js
@@ -55,18 +55,21 @@ limitations under the License.
                 },
                 enumerable: true
             });
-       
-        if (typeof authURI === "undefined") {
-            // Too few arguments. There must be at least {1}.
-            throw new Error(progress.data._getMsgText("jsdoMSG038", "1"));
-        }
         
-        if (typeof authURI === "string") {
-            authenticationURI = authURI;
-        } else {
+        if (typeof authURI !== "string") {
             // {1}: Argument {2} must be of type {3} in {4} call.
             throw new Error(progress.data._getMsgText("jsdoMSG121", "AuthenticationProvider", "1",
                                            "string", "constructor"));
+        } else if (authURI.length === 0) {
+            // {1}: Invalid value for {2} given for {3}.
+            throw new Error(progress.data._getMsgText(
+                "jsdoMSG127",
+                "AuthenticationProvider",
+                "authenticationURI",
+                "the constructor"
+            ));
+        } else {
+            authenticationURI = authURI;
         }
         
         options = options || {};
@@ -90,19 +93,21 @@ limitations under the License.
                 
                 // If the headerName string is empty, throw an error
                 if (options.tokenResponseDescriptor.headerName.length === 0) {
-                    // {1}: Invalid {2} given for a tokenResponseDescriptor or tokenRequestDescriptor.
+                    // {1}: Invalid value for {2} given for {3}.
                     throw new Error(progress.data._getMsgText(
                         "jsdoMSG127",
                         "AuthenticationProvider",
-                        "headerName"
+                        "headerName",
+                        "tokenResponseDescriptor"
                     ));
                 }
             } else {
-                // {1}: Invalid {2} given for a tokenResponseDescriptor or tokenRequestDescriptor.
+                // {1}: Invalid value for {2} given for {3}.
                 throw new Error(progress.data._getMsgText(
                     "jsdoMSG127",
                     "AuthenticationProvider",
-                    "type"
+                    "type",
+                    "tokenResponseDescriptor"
                 ));
             }
             
@@ -260,19 +265,21 @@ limitations under the License.
                 
                 // If the headerName string is empty, throw an error
                 if (options.tokenResponseDescriptor.headerName.length === 0) {
-                    // {1}: Invalid {2} given for a tokenResponseDescriptor or tokenRequestDescriptor.
+                    // {1}: Invalid value for {2} given for {3}.
                     throw new Error(progress.data._getMsgText(
                         "jsdoMSG127",
                         "AuthenticationConsumer",
-                        "headerName"
+                        "headerName",
+                        "tokenRequestDescriptor"
                     ));
                 }
             } else {
-                // {1}: Invalid {2} given for a tokenResponseDescriptor or tokenRequestDescriptor.
+                // {1}: Invalid value for {2} given for {3}.
                 throw new Error(progress.data._getMsgText(
                     "jsdoMSG127",
                     "AuthenticationConsumer",
-                    "type"
+                    "type",
+                    "tokenRequestDescriptor"
                 ));
             }
             

--- a/src/progress.auth.js
+++ b/src/progress.auth.js
@@ -61,12 +61,11 @@ limitations under the License.
             throw new Error(progress.data._getMsgText("jsdoMSG121", "AuthenticationProvider", "1",
                                            "string", "constructor"));
         } else if (authURI.length === 0) {
-            // {1}: Invalid value for {2} given for {3}.
+            // {1}: '{2}' cannot be an empty string.
             throw new Error(progress.data._getMsgText(
-                "jsdoMSG127",
+                "jsdoMSG501",
                 "AuthenticationProvider",
-                "authenticationURI",
-                "the constructor"
+                "authenticationURI"
             ));
         } else {
             authenticationURI = authURI;
@@ -81,9 +80,14 @@ limitations under the License.
         }
         
         if (options.tokenResponseDescriptor) {
-            // {1}: tokenResponseDescriptors and tokenRequestDescriptors must contain a type field.
+            // {1}: '{2}' objects must contain a '{3}' field.
             if (typeof options.tokenResponseDescriptor.type === "undefined") {
-                throw new Error(progress.data._getMsgText("jsdoMSG125", "AuthenticationProvider"));
+                throw new Error(progress.data._getMsgText(
+                    "jsdoMSG500",
+                    "AuthenticationProvider",
+                    "tokenResponseDescriptor",
+                    "type"
+                ));
             }
             
             if (options.tokenResponseDescriptor.type === progress.data.Session.HTTP_HEADER) {
@@ -93,21 +97,20 @@ limitations under the License.
                 
                 // If the headerName string is empty, throw an error
                 if (options.tokenResponseDescriptor.headerName.length === 0) {
-                    // {1}: Invalid value for {2} given for {3}.
+                    // {1}: '{2}' cannot be an empty string.
                     throw new Error(progress.data._getMsgText(
-                        "jsdoMSG127",
-                        "AuthenticationProvider",
-                        "headerName",
-                        "tokenResponseDescriptor"
+                        "jsdoMSG501",
+                        "tokenResponseDescriptor",
+                        "headerName"
                     ));
                 }
             } else {
-                // {1}: Invalid value for {2} given for {3}.
+                // {1}: The object '{2}' has an invalid value in the '{3}' field.
                 throw new Error(progress.data._getMsgText(
-                    "jsdoMSG127",
+                    "jsdoMSG502",
                     "AuthenticationProvider",
-                    "type",
-                    "tokenResponseDescriptor"
+                    "tokenResponseDescriptor",
+                    "type"
                 ));
             }
             
@@ -252,10 +255,21 @@ limitations under the License.
         
         options = options || {};
 
+        if (typeof options !== "object") {
+            // {1}: Argument {2} must be of type {3} in {4} call.
+            throw new Error(progress.data._getMsgText("jsdoMSG121", "AuthenticationConsumer", "2",
+                                           "object", "constructor"));
+        }
+        
         if (options.tokenRequestDescriptor) {
-            // {1}: tokenResponseDescriptors and tokenRequestDescriptors must contain a type field.
+            // {1}: '{2}' objects must contain a '{3}' field.
             if (typeof options.tokenRequestDescriptor.type === "undefined") {
-                throw new Error(progress.data._getMsgText("jsdoMSG125", "AuthenticationConsumer"));
+                throw new Error(progress.data._getMsgText(
+                    "jsdoMSG500",
+                    "AuthenticationConsumer",
+                    "tokenRequestDescriptor",
+                    "type"
+                ));
             }
 
             if (options.tokenRequestDescriptor.type === progress.data.Session.HTTP_HEADER) {
@@ -264,22 +278,21 @@ limitations under the License.
                 }
                 
                 // If the headerName string is empty, throw an error
-                if (options.tokenResponseDescriptor.headerName.length === 0) {
-                    // {1}: Invalid value for {2} given for {3}.
+                if (options.tokenRequestDescriptor.headerName.length === 0) {
+                    // {1}: '{2}' cannot be an empty string.
                     throw new Error(progress.data._getMsgText(
-                        "jsdoMSG127",
-                        "AuthenticationConsumer",
-                        "headerName",
-                        "tokenRequestDescriptor"
+                        "jsdoMSG501",
+                        "tokenRequestDescriptor",
+                        "headerName"
                     ));
                 }
             } else {
-                // {1}: Invalid value for {2} given for {3}.
+                // {1}: The object '{2}' has an invalid value in the '{3}' field.
                 throw new Error(progress.data._getMsgText(
-                    "jsdoMSG127",
+                    "jsdoMSG502",
                     "AuthenticationConsumer",
-                    "type",
-                    "tokenRequestDescriptor"
+                    "tokenRequestDescriptor",
+                    "type"
                 ));
             }
             

--- a/src/progress.auth.js
+++ b/src/progress.auth.js
@@ -47,15 +47,7 @@ limitations under the License.
                 },
                 enumerable: true
             });
-
-        Object.defineProperty(this, 'tokenResponseDescriptor',
-            {
-                get: function () {
-                    return tokenResponseDescriptor;
-                },
-                enumerable: true
-            });
-        
+                
         if (typeof authURI !== "string") {
             // {1}: Argument {2} must be of type {3} in {4} call.
             throw new Error(progress.data._getMsgText("jsdoMSG121", "AuthenticationProvider", "1",

--- a/src/progress.js
+++ b/src/progress.js
@@ -106,7 +106,7 @@ limitations under the License.
     msg.msgs.jsdoMSG100 = "JSDO: Unexpected HTTP response. Too many records.";
     msg.msgs.jsdoMSG101 = "Network error while executing HTTP request.";
 
-    //                    110 - 998 are for miscellaneous errors
+    //                    110 - 499 are for miscellaneous errors
     msg.msgs.jsdoMSG110 = "Catalog error: idProperty not specified for resource '{1}'. " +
         "idProperty is required {2}.";
     msg.msgs.jsdoMSG111 = "Catalog error: Schema '{1}' was not found in catalog.";
@@ -126,13 +126,13 @@ limitations under the License.
     msg.msgs.jsdoMSG123 = "{1}: A server response included an invalid '{2}' header.";
     msg.msgs.jsdoMSG124 = "JSDO: autoApplyChanges is not supported for saveChanges(true) " + 
                             "with a temp-table. Use jsdo.autoApplyChanges = false.";
-    msg.msgs.jsdoMSG125 = "{1}: tokenResponseDescriptors and tokenRequestDescriptors must" +
-        "contain a type field.";
-    msg.msgs.jsdoMSG126 = "{1}: tokenResponseDescriptors and tokenRequestDescriptors must" +
-        "contain a {2} field if they are of type {3}.";
-    msg.msgs.jsdoMSG127 = "{1}: Invalid value for {2} given for {3}.";
-    msg.msgs.jsdoMSG128 = "JSDOSession: The AuthenticationProvider given must already be authenticated.";
+    msg.msgs.jsdoMSG125 = "JSDOSession: The AuthenticationProvider given must already be authenticated.";
     
+    //                    500 - 998 are for generic errors
+    msg.msgs.jsdoMSG500 = "{1}: '{2}' objects must contain a '{3}' field.";
+    msg.msgs.jsdoMSG501 = "{1}: '{2}' cannot be an empty string.";
+    msg.msgs.jsdoMSG502 = "{1}: The object '{2}' has an invalid value in the '{3}' field.";
+
     msg.msgs.jsdoMSG998 = "JSDO: JSON object in addRecords() must be DataSet or Temp-Table data.";
 
     msg.getMsgText = function (n, args) {

--- a/src/progress.js
+++ b/src/progress.js
@@ -130,9 +130,9 @@ limitations under the License.
         "contain a type field.";
     msg.msgs.jsdoMSG126 = "{1}: tokenResponseDescriptors and tokenRequestDescriptors must" +
         "contain a {2} field if they are of type {3}.";
-    msg.msgs.jsdoMSG127 = "{1}: Invalid {2} given for a tokenResponseDescriptor or tokenRequestDescriptor.";
+    msg.msgs.jsdoMSG127 = "{1}: Invalid value for {2} given for {3}.";
     msg.msgs.jsdoMSG128 = "JSDOSession: The AuthenticationProvider given must already be authenticated.";
-	
+    
     msg.msgs.jsdoMSG998 = "JSDO: JSON object in addRecords() must be DataSet or Temp-Table data.";
 
     msg.getMsgText = function (n, args) {

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -3434,7 +3434,8 @@ limitations under the License.
                     // Our usage of isAuthenticated() here implies that if the user implements
                     // their own provider, it needs to have an isAuthenticated() method.
                     if (!options.authImpl.provider.isAuthenticated()) {
-                        throw new Error(progress.data._getMsgText("jsdoMSG128"));                        
+                        // JSDOSession: The AuthenticationProvider given must already be authenticated.
+                        throw new Error(progress.data._getMsgText("jsdoMSG125"));                        
                     }
                 }
             }


### PR DESCRIPTION
I removed the tokenResponseDescriptor property from the AuthenticationProvider object.

Alternative is to return a clone of the tokenResponseDescriptor whenever or make it have read-only properties. But we don't have a use-case for it now so YAGNI.