### PR TITLE
Sso/bug authentication signature change

### DIFF
--- a/src/SSOtests/SSOAuthenticationSignature.html
+++ b/src/SSOtests/SSOAuthenticationSignature.html
@@ -1,0 +1,137 @@
+<html>
+    <head>
+        <script src="http://cdn.kendostatic.com/2014.3.1316/js/jquery.min.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.util.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.session.js"></script>
+        <script src="C:\Users\aestrada\Documents\GitHub\JSDO\src\progress.auth.js"></script>	
+        
+    </head>
+    
+    <body>
+        <br/>
+        <br/>
+        <b>New Authentication Signature Tests</b>
+        <br/>
+
+        <script type="text/javascript">
+            // These are tests for the story TP 39671 where there is no validation done
+            // on the username and password passed to authenticate.
+
+            var auth = new progress.data.AuthenticationProvider(
+                "http://nbbedaestrada:8810/TS102/static/auth/j_spring_security_check"
+                //"http://nbbedsrapuri1:8810/SSO_Token_Server/static/auth/j_spring_security_check"
+            );
+            
+            // Call to authenticate with old signature
+            // This doubles as an invalid type for username
+            try {
+                document.write("<br/><br>Invalid Type for userName Test Case: <br/>");
+        
+                auth.authenticate({ userName: "restuser", password: "password"})
+                    .done(function (ap, result, info) {
+                    console.log("authenticate method succeeded");
+                
+                })
+                .fail(function (ap, result, info) {
+                    console.log("authenticate method failed");
+                });
+                
+                document.write("Failure: We didn't throw an error<br/>");
+            } catch (e) {
+                document.write("Success (Invalid type for userName): " + e);
+            } 
+                        
+            // Call with invalid type for password
+            try {
+                document.write("<br/><br/>Invalid Type for password Test Case: <br/>");
+                
+                auth.authenticate("restuser", 1)
+                    .done(function (ap, result, info) {
+                    console.log("authenticate method succeeded");
+                
+                })
+                .fail(function (ap, result, info) {
+                    console.log("authenticate method failed");
+                });
+                
+                document.write("Failure: We didn't throw an error<br/>");
+            } catch (e) {
+                document.write("Success (Invalid type for password): " + e);
+            }
+            
+            // Call with undefined password
+            try {
+                document.write("<br/><br/>Undefined for password Test Case: <br/>");
+                
+                auth.authenticate("restuser")
+                    .done(function (ap, result, info) {
+                    console.log("authenticate method succeeded");
+                
+                })
+                .fail(function (ap, result, info) {
+                    console.log("authenticate method failed");
+                });
+                
+                document.write("Failure: We didn't throw an error<br/>");
+            } catch (e) {
+                document.write("Success (Invalid type for password): " + e);
+            }
+            
+            // Call with empty string for userName
+            try {
+                document.write("<br/><br/>Empty String for userName Test Case: <br/>");
+                
+                auth.authenticate("", "password")
+                    .done(function (ap, result, info) {
+                    console.log("authenticate method succeeded");
+                
+                })
+                .fail(function (ap, result, info) {
+                    console.log("authenticate method failed");
+                });
+                
+                document.write("Failure: We didn't throw an error<br/>");
+            } catch (e) {
+                document.write("Success (Can't be empty string for userName): " + e);
+            }
+
+            // Call with empty string for password
+            try {
+                document.write("<br/><br/>Empty String for password Test Case: <br/>");
+                
+                auth.authenticate("restuser", "")
+                    .done(function (ap, result, info) {
+                    console.log("authenticate method succeeded");
+                
+                })
+                .fail(function (ap, result, info) {
+                    console.log("authenticate method failed");
+                });
+                
+                document.write("Failure: We didn't throw an error<br/>");
+            } catch (e) {
+                document.write("Success (Can't be empty string for password): " + e);
+            }
+            
+            // Call with empty string for password
+            try {
+                document.write("<br/><br/>Successful Authentication Test Case: <br/>");
+                
+                auth.authenticate("restuser", "password")
+                    .done(function (ap, result, info) {
+                    console.log("authenticate method succeeded");
+                
+                })
+                .fail(function (ap, result, info) {
+                    console.log("authenticate method failed");
+                });
+                
+                document.write("Success: We didn't throw an error<br/>");
+            } catch (e) {
+                document.write("Failure: " + e);
+            }
+            
+        </script> 
+    </body>
+</html>

--- a/src/progress.auth.js
+++ b/src/progress.auth.js
@@ -128,7 +128,7 @@ limitations under the License.
 
         // PRIVATE FUNCTIONS
 
-        function openTokenRequest(xhr, options) {
+        function openTokenRequest(xhr) {
             xhr.open('POST', that.authenticationURI, true);
             xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
             xhr.setRequestHeader("Cache-Control", "max-age=0");
@@ -221,10 +221,41 @@ limitations under the License.
             return (retrieveToken() === null ? false : true);
         };
         
-        this.authenticate = function (options) {
+        this.authenticate = function (userName, password) {
             var deferred = $.Deferred(),
                 xhr;
 
+            if (typeof userName !== "string") {
+                // JSDO: {1} parameter must be a string in {2} call.
+                throw new Error(progress.data._getMsgText(
+                    "jsdoMSG116",
+                    "userName",
+                    "authenticate()"
+                ));
+            } else if (userName.length === 0) {
+                // {1}: '{2}' cannot be an empty string.
+                throw new Error(progress.data._getMsgText(
+                    "jsdoMSG501",
+                    "AuthenticationProvider",
+                    "userName"
+                ));
+            }
+            
+            if (typeof password !== "string") {
+                // JSDO: {1} parameter must be a string in {2} call.
+                throw new Error(progress.data._getMsgText(
+                    "jsdoMSG116",
+                    "password",
+                    "authenticate()"
+                ));
+                // {1}: '{2}' cannot be an empty string.
+                throw new Error(progress.data._getMsgText(
+                    "jsdoMSG501",
+                    "AuthenticationProvider",
+                    "password"
+                ));
+            }
+            
             if (this.isAuthenticated()) {
                 // "authenticate() failed because the AuthenticationProvider is already managing a 
                 // successful authentication."
@@ -232,7 +263,7 @@ limitations under the License.
             }
 
             xhr = new XMLHttpRequest();
-            openTokenRequest(xhr, this, options);
+            openTokenRequest(xhr);
 
             xhr.onreadystatechange = function () {
                 if (xhr.readyState === 4) {
@@ -241,10 +272,9 @@ limitations under the License.
                 }
             };
 
-            xhr.send("j_username=" + options.userName + "&j_password=" + options.password +
+            xhr.send("j_username=" + userName + "&j_password=" + password +
                      "&submit=Submit" + "&OECP=1");
             return deferred;
-
         };
         
         this.invalidate = function () {
@@ -290,7 +320,7 @@ limitations under the License.
                     // {1}: The object '{2}' has an invalid value in the '{3}' property.
                     throw new Error(progress.data._getMsgText(
                         "jsdoMSG502",
-                        "AuthenticationProvider",
+                        "AuthenticationConsumer",
                         "tokenRequestDescriptor",
                         "headerName"
                     ));


### PR DESCRIPTION
* Changed the AuthenticationProvider authenticate method to have a userName and password parameters instead of an object. This includes changing all the references to options.userName and options.password to userName and password.

* Added error checking for each of the parameters. Both of them have to be strings and both of them cannot be empty. Wayne, do you see a scenario where we pass in a username but an empty password?