### PR TITLE
Sso/bugauthenticate promise

### DIFF
--- a/src/progress.auth.js
+++ b/src/progress.auth.js
@@ -1,5 +1,5 @@
 /* 
-progress.auth.js    Version: 4.3.0-6
+progress.auth.js    Version: 4.3.0-11
 
 Copyright (c) 2016 Progress Software Corporation and/or its subsidiaries or affiliates.
  
@@ -275,7 +275,7 @@ limitations under the License.
 
             xhr.send("j_username=" + userName + "&j_password=" + password +
                      "&submit=Submit" + "&OECP=1");
-            return deferred;
+            return deferred.promise();
         };
         
         this.invalidate = function () {

--- a/src/progress.auth.js
+++ b/src/progress.auth.js
@@ -248,6 +248,7 @@ limitations under the License.
                     "password",
                     "authenticate()"
                 ));
+            } else if (password.length === 0) {
                 // {1}: '{2}' cannot be an empty string.
                 throw new Error(progress.data._getMsgText(
                     "jsdoMSG501",


### PR DESCRIPTION
Changed the "return deferred;" in authenticate() to "return deferred.promise();", since the method is supposed to return a promise (had been working "accidentally" when using jQuery for promises).

Noticed that in the version of progress.auth.js on the develop branch, authenticate is missing an else statement where it does the validation of the password (if (typeof password !== "string") {
                                                                       ... else // check password.length
I put the "else" into this checkin, too, since it is in the SSO/bugAuthenticationSignatureChange branch.

Did not add a test because this was found with a tdriver test that is being developed and that Sravanthi will check in. It's part of the SSO_Authentication tests, specifically authenticate_method_tc1.
