### PR TITLE
Added a check to make sure token*Descriptors are objects and added a …

### DIFF
--- a/src/SSOtests/SSOemptyTokenRequestDescriptor.html
+++ b/src/SSOtests/SSOemptyTokenRequestDescriptor.html
@@ -1,0 +1,109 @@
+<html>
+    <head>
+        <script src="http://cdn.kendostatic.com/2014.3.1316/js/jquery.min.js"></script>
+        <script src="C:\Users\Blade\Documents\GitHub\JSDO\src\progress.util.js"></script>
+        <script src="C:\Users\Blade\Documents\GitHub\JSDO\src\progress.js"></script>
+        <script src="C:\Users\Blade\Documents\GitHub\JSDO\src\progress.session.js"></script>
+        <script src="C:\Users\Blade\Documents\GitHub\JSDO\src\progress.auth.js"></script>	
+        
+    </head>
+    
+    <body>
+        <br/>
+        <br/>
+        <b>Bug 40740: tokenResponseDescriptor cannot have an empty string in the JSDO session consumer</b>
+        <br/>
+
+        <script type="text/javascript">
+            // A bug where we can make an empty string for the tokenResponseDescriptor in the 
+            // JSDO session constructor
+
+            var auth = new progress.data.AuthenticationProvider(
+                "http://172.29.37.63:8810/TokenServer/static/auth/j_spring_security_check"
+                //"http://nbbedsrapuri1:8810/SSO_Token_Server/static/auth/j_spring_security_check"
+            );
+            
+            //auth.invalidate();
+            try {
+                auth.authenticate("restuser","password")
+                    .done(function (ap, result, info) {
+                        console.log("authenticate method succeeded");
+
+                    })
+                    .fail(function (ap, result, info) {
+                        console.log("authenticate method failed");
+                });
+            } catch (e) {
+                
+            }
+            
+            try {
+                document.write("<br/><br/>Invalid Type for tokenResponseDescriptor: <br/>");
+                
+                myDataSession = new progress.data.JSDOSession( {
+                    serviceURI: "http://172.29.37.63:8810/SSOConsumer", 
+                    authenticationModel : progress.data.Session.AUTH_TYPE_OECP,                 
+                    authImpl: {                            
+                        provider: auth,
+                        consumer: {
+                            tokenRequestDescriptor : ""
+                        }
+                    }
+                } );
+                
+                document.write("Failure: We didn't throw an error<br/>");
+            } catch (e) {
+                document.write("Success (must be of type object): " + e);
+            }
+            
+            try {
+                document.write("<br/><br/>Invalid Type for tokenResponseDescriptor: <br/>");
+                
+                var authProvider = new progress.data.AuthenticationProvider(
+                    "http://172.29.37.63:8810/TokenServer/static/auth/j_spring_security_check", 
+                    {
+                        tokenResponseDescriptor: "" 
+                    }
+                );
+                
+                document.write("Failure: We didn't throw an error<br/>");
+            } catch (e) {
+                document.write("Success (must be of type object): " + e);
+            }
+            
+            try {
+                document.write("<br/><br/>Basic authProvider Success Case: <br/>");
+                
+                var authProvider = new progress.data.AuthenticationProvider(
+                    "http://172.29.37.63:8810/TokenServer/static/auth/j_spring_security_check", 
+                    {
+                        tokenResponseDescriptor: {
+                            type: "header"
+                        }
+                    }
+                );
+                
+                document.write("Success: We didn't throw an error<br/>");
+            } catch (e) {
+                document.write("Failure: " + e);
+            }
+            
+            try {
+                document.write("<br/><br/>Basic authConsumer Success Case: <br/>");
+                
+                var authProvider = new progress.data.AuthenticationConsumer(
+                    {
+                        tokenResponseDescriptor: {
+                            type: "header"
+                        }
+                    }
+                );
+                
+                document.write("Success: We didn't throw an error<br/>");
+            } catch (e) {
+                document.write("Failure: " + e);
+            }
+            
+        </script> 
+    </body>
+</html>

--- a/src/progress.auth.js
+++ b/src/progress.auth.js
@@ -71,9 +71,18 @@ limitations under the License.
                                            "object", "constructor"));
         }
         
-        if (options.tokenResponseDescriptor) {
-            // {1}: '{2}' objects must contain a '{3}' field.
+        if (typeof options.tokenResponseDescriptor !== "undefined" &&
+                typeof options.tokenResponseDescriptor !== "object") {
+            // "{1}: '{2}' must be of type '{3}'"
+            throw new Error(progress.data._getMsgText(
+                "jsdoMSG503",
+                "AuthenticationProvider",
+                "tokenResponseDescriptor",
+                "object"
+            ));
+        } else if (options.tokenResponseDescriptor) {
             if (typeof options.tokenResponseDescriptor.type === "undefined") {
+                // {1}: '{2}' objects must contain a '{3}' field.
                 throw new Error(progress.data._getMsgText(
                     "jsdoMSG500",
                     "AuthenticationProvider",
@@ -303,9 +312,29 @@ limitations under the License.
                                            "object", "constructor"));
         }
         
-        if (options.tokenRequestDescriptor) {
-            // {1}: '{2}' objects must contain a '{3}' field.
+                
+        if (typeof options.tokenRequestDescriptor !== "undefined" &&
+                typeof options.tokenRequestDescriptor !== "object") {
+            // "{1}: '{2}' must be of type '{3}'"
+            throw new Error(progress.data._getMsgText(
+                "jsdoMSG503",
+                "AuthenticationProvider",
+                "tokenRequestDescriptor",
+                "object"
+            ));
+        } else if (options.tokenRequestDescriptor) {
+            if (typeof options.tokenRequestDescriptor !== "object") {
+                // "{1}: '{2}' must be of type '{3}'"
+                throw new Error(progress.data._getMsgText(
+                    "jsdoMSG503",
+                    "AuthenticationConsumer",
+                    "tokenRequestDescriptor",
+                    "object"
+                ));
+            }
+            
             if (typeof options.tokenRequestDescriptor.type === "undefined") {
+                // {1}: '{2}' objects must contain a '{3}' field.
                 throw new Error(progress.data._getMsgText(
                     "jsdoMSG500",
                     "AuthenticationConsumer",

--- a/src/progress.js
+++ b/src/progress.js
@@ -132,6 +132,7 @@ limitations under the License.
     msg.msgs.jsdoMSG500 = "{1}: '{2}' objects must contain a '{3}' property.";
     msg.msgs.jsdoMSG501 = "{1}: '{2}' cannot be an empty string.";
     msg.msgs.jsdoMSG502 = "{1}: The object '{2}' has an invalid value in the '{3}' property.";
+    msg.msgs.jsdoMSG503 = "{1}: '{2}' must be of type '{3}'";
 
     msg.msgs.jsdoMSG998 = "JSDO: JSON object in addRecords() must be DataSet or Temp-Table data.";
 


### PR DESCRIPTION
…unit test.

Added an error message and this fix solves both the tokenResponseDescriptor and the tokenRequestDescriptor bugs!

Weird thing, I ran:

submobile/nonui/SSO_Authentication
submobile/nonui/SSO_Authentication suffix=min filetype=min

And both these tests failed and I can't figure out why. Fortunately, these tests both fail on the develop branch as well so I don't think it's this bug fix's fault.