### PR TITLE
Added clearing sessionStorage when  we logout

### DIFF
--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -3730,9 +3730,8 @@ limitations under the License.
             .then(function(jsdosession, result, info) {
                 deferred.resolve(jsdosession, progress.data.Session.SUCCESS);
             }, rejectHandler);
-            
         };
-        //
+        
         if (typeof options !== 'object') {
             // getSession(): 'options' must be of type 'object'
             throw new Error(progress.data._getMsgText(
@@ -3783,15 +3782,13 @@ limitations under the License.
         // Create the JSDOSession and let it handle the argument parsing
         try {
             jsdosession = new progress.data.JSDOSession(options);
-            
+
             jsdosession.login(options.username, options.password)
             .then(loginHandler, rejectHandler);
-
-        } catch (e) {
-            throw e;
+        } catch (error) {
+            throw error;
         }
-
-        deferred.resolve(jsdosession, progress.data.Session.SUCCESS);
+        
         return deferred.promise();
     };
 })();

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -3747,6 +3747,16 @@ limitations under the License.
             ));
         }
         
+        if (typeof options.loginCallback !== 'function') {
+            // getSession(): 'options.loginCallback' must be of type 'function'
+            throw new Error(progress.data._getMsgText(
+                "jsdoMSG503", 
+                "getSession()",
+                "options.loginCallback",
+                "function"
+            ));
+        }
+        
         // Create the JSDOSession and let it handle the argument parsing
         try {
             jsdosession = new progress.data.JSDOSession(options);

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -1068,6 +1068,7 @@ limitations under the License.
                 setLoginHttpStatus(parseInt(sessionStorage.getItem(_storageKey + "." + "loginHttpStatus")));
                 setClientContextID(sessionStorage.getItem(_storageKey + "." + "clientContextId"));
                 
+                          // need to get these too for the connected property
                                 // && restApplicationIsOnline 
                                 // && deviceIsOnline;
                 

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -968,6 +968,17 @@ limitations under the License.
                 return value;
             }
         }
+        
+        function clearSessionInfo(infoName) {
+            var key;
+            if (typeof (sessionStorage) === 'object' && _storageKey) {
+                key = _storageKey;
+                if (infoName) {
+                    key = key + "." + infoName;
+                    sessionStorage.removeItem(key);
+                }
+            }
+        }
 
 
         
@@ -1739,6 +1750,20 @@ limitations under the License.
                 */ 
                 deferred = args.deferred;
                 jsdosession = args.jsdosession;                    
+            }
+            
+            // Let's clear sessionStorage since we are logging out!
+            if (_storageKey) {
+                if (retrieveSessionInfo(_storageKey)) {
+                    clearSessionInfo("loginResult");
+                    clearSessionInfo("userName");
+                    clearSessionInfo("serviceURI");
+                    clearSessionInfo("loginHttpStatus");
+                    clearSessionInfo("clientContextId");
+                    clearSessionInfo("deviceIsOnline");
+                    clearSessionInfo("restApplicationIsOnline");
+                    clearSessionInfo(_storageKey);
+                }
             }
 
             xhr = new XMLHttpRequest();

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -930,11 +930,34 @@ limitations under the License.
             this.lastSessionXHR = null;
         }
 
+        // stores data value using the JSDOSession's storage key plus the infoName
+        // argument as a key. If there is no infoName, just uses the storage key
+        // by itself (the latter case is inetnded to serev as a flag that we have
+        // stored this JSDOSession's data before)
+        // 
         function storeSessionInfo(infoName, value) {
+            var key;
             if (typeof (sessionStorage) === 'object' && _storageKey) {
-                sessionStorage.setItem(_storageKey + "." + infoName, value);
+                key = _storageKey;
+                if (infoName) {
+                    key = key + "." + infoName;
+                }
+                sessionStorage.setItem(key, JSON.stringify(value));
             }
         }
+
+        function retrieveSessionInfo(infoName, value) {
+            var key;
+            if (typeof (sessionStorage) === 'object' && _storageKey) {
+                key = _storageKey;
+                if (infoName) {
+                    key = key + "." + infoName;
+                }
+                return (JSON.parse(sessionStorage.getItem(key)));
+            }
+        }
+
+
         
         function setUserName(newname, sessionObject) {
             if (defPropSupported) {
@@ -1060,17 +1083,23 @@ limitations under the License.
         // use it to try to retrieve state data from a previous JSDOSession instance that 
         // had the same name. This code was introduced to handle page refreshes, but could
         // be used for other purposes.
-        if (typeof(options) === 'object') {
+        if (typeof (options) === 'object') {
             _storageKey = options._storageKey;
             if (_storageKey) {
-                setLoginResult(parseInt(sessionStorage.getItem(_storageKey + "." + "loginResult")));
-                setUserName(sessionStorage.getItem(_storageKey + "." + "userName"));
-                setServiceURI(sessionStorage.getItem(_storageKey + "." + "serviceURI"));
-                setLoginHttpStatus(parseInt(sessionStorage.getItem(_storageKey + "." + "loginHttpStatus")));
-                setClientContextID(sessionStorage.getItem(_storageKey + "." + "clientContextId"));
-                setDeviceIsOnline(sessionStorage.getItem(_storageKey + "." + "deviceIsOnline"));
-                setRestApplicationIsOnline(
-                         sessionStorage.getItem(_storageKey + "." + "restApplicationIsOnline"));
+                if (retrieveSessionInfo(_storageKey)) {
+                    setLoginResult(retrieveSessionInfo("loginResult"));
+                    setUserName(retrieveSessionInfo("userName"));
+                    setServiceURI(retrieveSessionInfo("serviceURI"));
+                    setLoginHttpStatus(retrieveSessionInfo("loginHttpStatus"));
+                    setClientContextID(retrieveSessionInfo("clientContextId"));
+                    setDeviceIsOnline(retrieveSessionInfo("deviceIsOnline"));
+                    setRestApplicationIsOnline(retrieveSessionInfo("restApplicationIsOnline"));
+                } else {
+                    // A storage key was passed in, but has not been used for storing yet. Therefore
+                    // we are creating this particular Session for the first time, so store the key
+                    // so we know to read data from storage in the future
+                    storeSessionInfo(_storageKey, true);
+                }
             }
         }
         

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -3532,24 +3532,9 @@ limitations under the License.
                     throw new Error("JSDOSession: Unable to validate authorization. " + e.message);
                 }
             } else {
-                if (this.loginResult === null ||
-                    this.loginResult === progress.data.Session.AUTHENTICATION_FAILURE) {
-                    // Although this method can return a result of AUTHENTICATION_FAILURE,
-                    // this is not the place to do it. We only do that if loginResult was
-                    // LOGIN_SUCCESS -- i.e., the JSDOSession considered itself to be logged in, 
-                    // and then we discovered that the credentials are no longer good. 
-                    // The significance of isAuthorized() returning AUTHENTICATION_FAILURE is that
-                    // the JSDOSession needs to log in again, but first it needs to be "reinitialized",
-                    // and the caller needs to be able to distinguish that from the case where it does
-                    // not need reinitialization. Therefore, if we are here, 
-                    // we need to return LOGIN_AUTHENTICATION_REQUIRED, which means "you weren't in a
-                    // logged in state, so don't try to log out, just go ahead and try to log in"
-                    result = progress.data.Session.LOGIN_AUTHENTICATION_REQUIRED;
-                } else {
-                    // whatever
-                    result = this.loginResult;
-                }
-                
+                // Never logged in (or logged in and logged out). Regardless of what the reason
+                // was that there wasn't a login, the bottom line is that authentication is required
+                result = progress.data.Session.LOGIN_AUTHENTICATION_REQUIRED;
                 deferred.reject(that, result, {xhr: xhr});
             }
 

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -1,6 +1,6 @@
 
 /* 
-progress.session.js    Version: 4.3.0-14
+progress.session.js    Version: 4.3.0-15
 
 Copyright (c) 2012-2015 Progress Software Corporation and/or its subsidiaries or affiliates.
  
@@ -942,18 +942,30 @@ limitations under the License.
                 if (infoName) {
                     key = key + "." + infoName;
                 }
-                sessionStorage.setItem(key, JSON.stringify(value));
+                if (typeof (value) !== 'undefined') {
+                    sessionStorage.setItem(key, JSON.stringify(value));
+                }
             }
         }
 
-        function retrieveSessionInfo(infoName, value) {
-            var key;
+        function retrieveSessionInfo(infoName) {
+            var key,
+                jsonStr,
+                value = null;
             if (typeof (sessionStorage) === 'object' && _storageKey) {
                 key = _storageKey;
                 if (infoName) {
                     key = key + "." + infoName;
                 }
-                return (JSON.parse(sessionStorage.getItem(key)));
+                jsonStr = sessionStorage.getItem(key);
+                if (jsonStr !== null) {
+                    try {
+                        value = JSON.parse(jsonStr);
+                    } catch (e) {
+                        value = null;
+                    }
+                }
+                return value;
             }
         }
 

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -3718,11 +3718,13 @@ limitations under the License.
 
     progress.data.getSession = function(options) {
 
-         var deferred = $.Deferred(), 
-             jsdosession;
+         var deferred = $.Deferred();
              
         function rejectHandler(jsdosession, result, info) {
-            deferred.reject(result, info); 
+            if (jsdosession.loginResult) {
+                jsdosession.logout();
+            }
+            deferred.reject(result, info);
         }; 
                  
         function loginHandler(jsdosession, result, info) {
@@ -3740,43 +3742,6 @@ limitations under the License.
                 "options",
                 "object"
             ));
-        }
-        
-        if (options.authenticationModel !== progress.data.Session.AUTH_TYPE_FORM &&
-            options.authenticationModel !== progress.data.Session.AUTH_TYPE_BASIC &&
-            options.authenticationModel !== progress.data.Session.AUTH_TYPE_ANON) {
-            // getSession(): The object 'options' has an invalid value 
-            // in the 'authenticationModel' property.
-            throw new Error(progress.data._getMsgText(
-                "jsdoMSG502", 
-                "getSession()",
-                "options",
-                "authenticationModel"
-            ));
-        }
-        
-        // Check to make sure that we pass in a username/password.
-        // Note to Wayne: Do we want to do this or should we just pass whatever?
-        if (options.authenticationModel === progress.data.Session.AUTH_TYPE_FORM ||
-            options.authenticationModel === progress.data.Session.AUTH_TYPE_BASIC) {
-            if (typeof options.username === 'undefined') {
-                // getSession(): 'options' objects must contain a 'username' property
-                throw new Error(progress.data._getMsgText(
-                    "jsdoMSG500", 
-                    "getSession()",
-                    "options",
-                    "username"
-                ));
-            }
-            if (typeof options.password === 'undefined') {
-                // getSession(): 'options' objects must contain a 'password' property
-                throw new Error(progress.data._getMsgText(
-                    "jsdoMSG500", 
-                    "getSession()",
-                    "options",
-                    "password"
-                ));
-            }
         }
         
         // Create the JSDOSession and let it handle the argument parsing


### PR DESCRIPTION
Its interesting to note that some will be cleared and be null  while  others will be "null".

This is because reinitializeafterLogout actually sets some values like userName and loginResult to "null" manually.

An alternative  would  be to clear it  in reinitializeAfterLogout but I say that we try to clear it up as soon as possible to prevent lingering data from the customer.