### PR TITLE
Tp69885

### DIFF
--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -3580,7 +3580,13 @@ limitations under the License.
         function onAfterAddCatalog( pdsession, result, errorObject, xhr ) {
             var deferred,
                 fulfill = false,
+                settleResult;
+            
+            if (result === progress.data.Session.EXPIRED_TOKEN) {
+                settleResult = progress.data.Session.EXPIRED_TOKEN;
+            } else {
                 settleResult = progress.data.Session.GENERAL_FAILURE;
+            }
             
             if (xhr && xhr._deferred) {           
                 deferred  = xhr._deferred;


### PR DESCRIPTION
Added a fix for addCatalog() to return TOKEN_EXPIRED if we tried to add a catalog with an expired token.