### PR TITLE
TP Issue - 71515: Result code returned by getSession promise handler should be 2 (AUTHENTICATION_FAILURE) in the case of service provider and authProvider using different credentials

### DIFF
--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -1,5 +1,5 @@
 /* 
-progress.session.js    Version: 4.4.0-10
+progress.session.js    Version: 4.5.0-1
 
 Copyright (c) 2012-2017 Progress Software Corporation and/or its subsidiaries or affiliates.
  
@@ -3584,10 +3584,12 @@ limitations under the License.
             
             if (result === progress.data.Session.EXPIRED_TOKEN) {
                 settleResult = progress.data.Session.EXPIRED_TOKEN;
-            } else {
+            } else if (result === progress.data.Session.LOGIN_AUTHENTICATION_FAILURE){
+		settleResult = progress.data.Session.LOGIN_AUTHENTICATION_FAILURE;
+	    } else {
                 settleResult = progress.data.Session.GENERAL_FAILURE;
             }
-            
+		
             if (xhr && xhr._deferred) {           
                 deferred  = xhr._deferred;
                 


### PR DESCRIPTION
When we have configuration setup such that the authProvider and service provider are configured with different set of credentials and the JSDO catalog is protected, in this scenario, promise returned by getSession handler should include result code as 2 (Authentication Failure) instead of 3 (General Failure).

Current Behavior: Currently it returns 3 (GENERAL_FAILURE). However, the xhr's response shows result code as 'AUTHENTICATION_FAILURE'