### PR TITLE
Fixed bug TP-79017

### DIFF
--- a/src/progress.js
+++ b/src/progress.js
@@ -1,5 +1,5 @@
 /* 
-progress.js    Version: 4.5.0-03
+progress.js    Version: 4.5.0-04
 
 Copyright (c) 2012-2017 Progress Software Corporation and/or its subsidiaries or affiliates.
  
@@ -115,6 +115,7 @@ limitations under the License.
     msg.msgs.jsdoMSG060 = "AuthenticationProvider: AuthenticationProvider is no longer logged in. " +
         "Tried to refresh SSO token but failed due to authentication error at token server.";
     msg.msgs.jsdoMSG061 = "{1}: Attempted to set {2} property to an invalid value.";
+    msg.msgs.jsdoMSG062 = "{1}: Cannot call {2} when an AuthProvider is already available and logged in.";
     
     //                    100 - 109 relate to network errors
     msg.msgs.jsdoMSG100 = "JSDO: Unexpected HTTP response. Too many records.";

--- a/src/progress.js
+++ b/src/progress.js
@@ -115,7 +115,7 @@ limitations under the License.
     msg.msgs.jsdoMSG060 = "AuthenticationProvider: AuthenticationProvider is no longer logged in. " +
         "Tried to refresh SSO token but failed due to authentication error at token server.";
     msg.msgs.jsdoMSG061 = "{1}: Attempted to set {2} property to an invalid value.";
-    msg.msgs.jsdoMSG062 = "{1}: Cannot call {2} when an AuthProvider is already available and logged in.";
+    msg.msgs.jsdoMSG062 = "{1}: Cannot call {2} when an AuthenticationProvider is already available and logged in.";
     
     //                    100 - 109 relate to network errors
     msg.msgs.jsdoMSG100 = "JSDO: Unexpected HTTP response. Too many records.";

--- a/src/progress.session.js
+++ b/src/progress.session.js
@@ -1,5 +1,5 @@
 /*
-progress.session.js    Version: 4.5.0-3
+progress.session.js    Version: 4.5.0-4
 
 Copyright (c) 2012-2017 Progress Software Corporation and/or its subsidiaries or affiliates.
 
@@ -4048,6 +4048,9 @@ limitations under the License.
                 iOSBasicAuthTimeout = options.iOSBasicAuthTimeout;
             }
 
+            // As part of JSDOSession's login we create a new authProvider always. However, when a valid
+            // authProvider is provided as part of JSDOSession's constructor. i.e., when we already have
+            // a valid authProvider, performing login operation is not allowed. We throw an error.
             if (!_pdsession._authProvider) {
                 // is there a better way to do this? Need it because we didn't have the authprovider when
                 // running the constructor
@@ -4055,9 +4058,8 @@ limitations under the License.
                     uri: this.serviceURI,
                     authenticationModel: this.authenticationModel
                 });
-            }
 
-            _pdsession._authProvider.logout()
+                _pdsession._authProvider.logout()
                 .then(function () {
                     return _pdsession._authProvider.login(username, password);
                 })
@@ -4066,6 +4068,9 @@ limitations under the License.
                 }, function (provider, result, info) {
                     deferred.reject(that, result, info);
                 });
+            } else {
+                throw new Error(progress.data._getMsgText("jsdoMSG062", 'JSDOSession', 'login()'));
+            }
 
             return deferred.promise();
         };


### PR DESCRIPTION
**Problem Description or Analysis**: As part of performing jsdoSessionLogin, we do internally perform authProviderLogin as well after authProviderLogout operation.

After which we check for the validity of the session i.e., performing isAuthorized() via a local function named callIsAuthorized() which expects username and password for basic authModdel's authorization. In our scenario, username and password are empty which were cleared as part of the authProvider's logout operation.

However, when we already have a valid authProvider which is logged in then it is still trying to proceed with another login (jsdoSession.login) which is not right.

**Fix**: Checking for the availability of authProvider in jsdoSession's login operation and throwing an error if the authProvider is already available as part of the JSDOSession constructor